### PR TITLE
Change cronjob execution and add custom config file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ Pi:
 
 ```
 SHELL=/bin/bash
-* * * * * if ( ! pidof python ) ; then /usr/bin/python /home/pi/monitor.py /dev/hidraw0 > /dev/null 2>&1 ; fi
+* * * * * /usr/bin/python /home/pi/monitor.py /dev/hidraw0 [ **optional:** /home/pi/my_config.yaml ]  > /dev/null 2>&1
 ```
 
-This assumes that only one python is running on the box...
+The script will default to using "config.yaml" (residing in the same directory as the
+monitor.py script - /home/pi in the example) for the librato credentials.
+You can optionally override this by passing a custom configuration file path as a second parameter.
 
 # credits
 

--- a/monitor.py
+++ b/monitor.py
@@ -8,27 +8,27 @@ import sys, fcntl, time, librato, yaml
 def decrypt(key,  data):
     cstate = [0x48,  0x74,  0x65,  0x6D,  0x70,  0x39,  0x39,  0x65]
     shuffle = [2, 4, 0, 7, 1, 6, 5, 3]
-    
+
     phase1 = [0] * 8
     for i, o in enumerate(shuffle):
         phase1[o] = data[i]
-    
+
     phase2 = [0] * 8
     for i in range(8):
         phase2[i] = phase1[i] ^ key[i]
-    
+
     phase3 = [0] * 8
     for i in range(8):
         phase3[i] = ( (phase2[i] >> 3) | (phase2[ (i-1+8)%8 ] << 5) ) & 0xff
-    
+
     ctmp = [0] * 8
     for i in range(8):
         ctmp[i] = ( (cstate[i] >> 4) | (cstate[i]<<4) ) & 0xff
-    
+
     out = [0] * 8
     for i in range(8):
         out[i] = (0x100 + phase3[i] - ctmp[i]) & 0xff
-    
+
     return out
 
 def hd(d):
@@ -44,8 +44,15 @@ def publish(client, prefix, co2, tmp):
     except:
         print "Unexpected error:", sys.exc_info()[0]
 
-def config():
-    with open("config.yaml", 'r') as stream:
+def config(config_file=None):
+    """Get config from file; if no config_file is passed in as argument
+        default to "config.yaml" in script dir"""
+
+    if config_file is None:
+        script_base_dir = os.path.dirname(os.path.realpath(sys.argv[0])) + "/"
+        config_file = script_base_dir + "config.yaml"
+
+    with open(config_file, 'r') as stream:
         return yaml.load(stream)
 
 def client(config):
@@ -53,15 +60,20 @@ def client(config):
 
 
 if __name__ == "__main__":
-    key = [0xc4, 0xc6, 0xc0, 0x92, 0x40, 0x23, 0xdc, 0x96]    
+    key = [0xc4, 0xc6, 0xc0, 0x92, 0x40, 0x23, 0xdc, 0x96]
     fp = open(sys.argv[1], "a+b",  0)
     HIDIOCSFEATURE_9 = 0xC0094806
     set_report = "\x00" + "".join(chr(e) for e in key)
     fcntl.ioctl(fp, HIDIOCSFEATURE_9, set_report)
-    
+
     values = {}
     stamp = now()
-    config = config()
+
+    try:
+        config = config(config_file=sys.argv[2])
+    except IndexError:
+        config = config()
+
     client = client(config)
 
     while True:
@@ -73,12 +85,12 @@ if __name__ == "__main__":
             op = decrypted[0]
             val = decrypted[1] << 8 | decrypted[2]
             values[op] = val
-            
+
             if (0x50 in values) and (0x42 in values):
                 co2 = values[0x50]
                 tmp = (values[0x42]/16.0-273.15)
                 print "CO2: %4i TMP: %3.1f" % (co2, tmp)
                 if now() - stamp > 5:
                     print ">>>"
-                    publish(client, config["prefix"], co2, tmp) 
+                    publish(client, config["prefix"], co2, tmp)
                     stamp = now()

--- a/monitor.py
+++ b/monitor.py
@@ -3,7 +3,7 @@
 # based on code by henryk ploetz
 # https://hackaday.io/project/5301-reverse-engineering-a-low-cost-usb-co-monitor/log/17909-all-your-base-are-belong-to-us
 
-import sys, fcntl, time, librato, yaml
+import os, sys, fcntl, time, librato, yaml, socket
 
 def decrypt(key,  data):
     cstate = [0x48,  0x74,  0x65,  0x6D,  0x70,  0x39,  0x39,  0x65]
@@ -60,6 +60,17 @@ def client(config):
 
 
 if __name__ == "__main__":
+    """main"""
+
+    # use lock on socket to indicate that script is already running
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        ## Create an abstract socket, by prefixing it with null.
+        s.bind('\0postconnect_gateway_notify_lock')
+    except socket.error, e:
+        # if script is already running just exit silently
+        sys.exit(0)
+
     key = [0xc4, 0xc6, 0xc0, 0x92, 0x40, 0x23, 0xdc, 0x96]
     fp = open(sys.argv[1], "a+b",  0)
     HIDIOCSFEATURE_9 = 0xC0094806


### PR DESCRIPTION
Please review this PR in which I made two changes.
1) I changed the way the script makes sure that it is not already running. Instead of executing a " if (!  pidof python ); then.." in the crontab I am now creating a socket based lock which is checked at the beginning of the script. If the script is able to get a lock it will start running; if not it will exit silently. This should be "crash resistant" and is definitely reboot resistant (I tried it several times).
2) I added the option to pass a (custom) config file when calling the script from the command line. This will default to using a file called "config.yaml" placed in the directory of the script and should therefore not change the current behavior at all if not used (the current script only works if the "config.yaml" file is located it the home directory of the user for whom the cronjob is set up!).

My customized VIM installation also (automatically) removed quite a few unneeded whitespaces (mostly on blank lines).