### PR TITLE
add slack webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ prefix: office.floor3
 
 We use [librato](https://www.librato.com) to graph our weather, so you'll need to modify that if you using another service.
 
+2b) (optional) You can configure this bot to automatically post to a Slack channel.
+Just add an "Incoming Webhook" to your Slack team's integrations and add a `slack` hash to the config file.
+
+```yaml
+slack:
+    webhook: 'https://hooks.slack.com/services/TXXXXXX/XXXXXX/xxxxxxx'
+    channel: '#general'   # optional - this is the default value
+    botname: 'CO2bot'     # optional - this is the default value
+    icon: ':monkey_face:' # optional - this is the default value
+    upper_threshold: 800  # optional - this is the default value
+    lower_threshold: 600  # optional - this is the default value
+```
+
 3) fix socket permissions
 ```
 sudo chmod a+rw /dev/hidraw0

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -2,3 +2,11 @@
 prefix: office.floor4.kitchen
 user: foo@bar.com
 token: 'sometoken'
+
+slack:
+    webhook: 'https://hooks.slack.com/services/TXXXXXX/XXXXXX/xxxxxxx'
+    channel: '#general'
+    botname: 'CO2bot'
+    icon: ':monkey_face:'
+    upper_threshold: 800
+    lower_threshold: 600


### PR DESCRIPTION
When the CO2 level is above a configurable threshold, a notification to a configured Slack webhook is sent.
When the level then falls below the lower thresholad, it notifies Slack again.